### PR TITLE
Update to GNOME 47

### DIFF
--- a/com.github.rafostar.Clapper.json
+++ b/com.github.rafostar.Clapper.json
@@ -1,11 +1,11 @@
 {
     "app-id": "com.github.rafostar.Clapper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
-            "version": "23.08",
+            "version": "24.08",
             "directory": "lib/ffmpeg",
             "add-ld-path": ".",
             "no-autodownload": false,


### PR DESCRIPTION
Mostly for testing if https://github.com/flathub/de.schmidhuberj.tubefeeder/pull/38 happens in Clapper-only.