### PR TITLE
Remove libmicrodns cleanup step

### DIFF
--- a/lib/libmicrodns.json
+++ b/lib/libmicrodns.json
@@ -6,10 +6,6 @@
         "-Dtests=disabled",
         "-Dexamples=disabled"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig"
-    ],
     "sources": [
         {
             "type": "git",


### PR DESCRIPTION
Its generated headers and pkgconfig files are required to use libclapper pkgconfig file for compiling stuff. With them removed, we cannot have enhancers built later on.