### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/com.github.rafostar.Clapper.json
+++ b/com.github.rafostar.Clapper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.rafostar.Clapper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {


### PR DESCRIPTION
tested with `flatpak run --runtime-version=48 com.github.rafostar.Clapper`