### PR TITLE
Build fix

### DIFF
--- a/lib/liba52.json
+++ b/lib/liba52.json
@@ -5,9 +5,10 @@
     "cleanup": [ "/bin/*a52*" ],
     "sources": [
         {
-            "type": "archive",
-            "url": "https://distfiles.adelielinux.org/source/a52dec/a52dec-0.8.0.tar.gz",
-            "sha256": "03c181ce9c3fe0d2f5130de18dab9bd8bc63c354071515aa56983c74a9cffcc9"
+            "type": "git",
+            "url": "https://git.adelielinux.org/community/a52dec.git",
+            "tag": "v0.8.0",
+            "commit": "c388f3b6d911c246e0b2a7b2c436c3de2e79c74d"
         },
         {
             "type": "patch",


### PR DESCRIPTION
GitHub CI times out downloading tar archive from adelielinux distfiles, even through download link works fine locally. Since the issue persisted for over a week now, work around this by pulling source code from git repo instead.