### PR TITLE
Change a52dec source url and update enhancers

### DIFF
--- a/com.github.rafostar.Clapper.json
+++ b/com.github.rafostar.Clapper.json
@@ -93,8 +93,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/Rafostar/clapper-enhancers.git",
-                    "tag": "0.8.2",
-                    "commit": "a695ffc5ef2ab3f09894a6a41f0fdb2aad5897d6",
+                    "tag": "0.8.3",
+                    "commit": "29eb9bf06fd221e34b38a1c17a7a294706f8d0a5",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"

--- a/lib/liba52.json
+++ b/lib/liba52.json
@@ -6,7 +6,7 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://distfiles.adelielinux.org/source/a52dec/a52dec-0.8.0.tar.gz",
+            "url": "https://plug-mirror.rcac.purdue.edu/adelie/source/a52dec/a52dec-0.8.0.tar.gz",
             "sha256": "03c181ce9c3fe0d2f5130de18dab9bd8bc63c354071515aa56983c74a9cffcc9"
         },
         {

--- a/lib/python-modules.json
+++ b/lib/python-modules.json
@@ -12,8 +12,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/a4/97/73eadf12412173dc518897a2715693e6caa73d6550ddf0b7c47c6f1e7703/yt_dlp-2025.1.15-py3-none-any.whl",
-            "sha256": "b8666b88e23c3fa5ee1e80920f4a9dfac7c405504a447214c0cf3d0c386edcfc",
+            "url": "https://files.pythonhosted.org/packages/25/68/4f108193ebce3ee7beb5f9a21daa6bc875e261150b510be468626f151959/yt_dlp-2025.5.22-py3-none-any.whl",
+            "sha256": "a49c4b76afeaded6254c3e2b759d8d5a13271aa963d5fccb51fe059d1c313151",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "yt-dlp",


### PR DESCRIPTION
Default url does not want to work with github CI, preventing app from being built. The same issue happens with trying to use git repo instead of archive unfortunately.