### PR TITLE
Fix libmpeg2 source again

### DIFF
--- a/lib/libmpeg2.json
+++ b/lib/libmpeg2.json
@@ -6,7 +6,7 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://fossies.org/linux/privat/old/libmpeg2-0.5.1.tar.gz",
+            "url": "https://web.archive.org/web/20250314123645id_/libmpeg2.sourceforge.io/files/libmpeg2-0.5.1.tar.gz",
             "sha256": "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
         },
         {


### PR DESCRIPTION
Previous archive sometimes requires CAPTCHA, so try again.