### PR TITLE
Update flatpak runtime to Gnome 49

### DIFF
--- a/com.github.rafostar.Clapper.json
+++ b/com.github.rafostar.Clapper.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.rafostar.Clapper",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {


### PR DESCRIPTION
flatpak runtime gnome 47 is EOL, please update runtime to gnome 48/49, thank you. 